### PR TITLE
Add commands

### DIFF
--- a/storage/commands.go
+++ b/storage/commands.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"strconv"
 )
 
@@ -192,4 +193,16 @@ func (s *Storage) GetRange(k string, start, end int) string {
 	}
 
 	return v[start : end+1]
+}
+
+func (s *Storage) Rename(k, nk string) (bool, error) {
+	if _, ok := s.state[k]; !ok {
+		return false, errors.New("ERR no such key")
+	}
+
+	v := s.state[k]
+	delete(s.state, k)
+	s.state[nk] = v
+
+	return true, nil
 }

--- a/storage/commands.go
+++ b/storage/commands.go
@@ -144,3 +144,16 @@ func (s *Storage) MSetNX(kvs ...string) bool {
 func (s *Storage) StrLen(k string) int {
 	return len(s.state[k])
 }
+
+func (s *Storage) Del(ks ...string) int {
+	t := 0
+
+	for i, _ := range ks {
+		if _, ok := s.state[ks[i]]; ok {
+			t++
+			delete(s.state, ks[i])
+		}
+	}
+
+	return t
+}

--- a/storage/commands.go
+++ b/storage/commands.go
@@ -161,3 +161,9 @@ func (s *Storage) Del(ks ...string) int {
 func (s *Storage) FlushAll() {
 	s.state = make(map[string]string)
 }
+
+func (s *Storage) Exists(k string) bool {
+	_, ok := s.state[k]
+
+	return ok
+}

--- a/storage/commands.go
+++ b/storage/commands.go
@@ -157,3 +157,7 @@ func (s *Storage) Del(ks ...string) int {
 
 	return t
 }
+
+func (s *Storage) FlushAll() {
+	s.state = make(map[string]string)
+}

--- a/storage/commands.go
+++ b/storage/commands.go
@@ -167,3 +167,29 @@ func (s *Storage) Exists(k string) bool {
 
 	return ok
 }
+
+func (s *Storage) GetRange(k string, start, end int) string {
+	l := len(s.state[k])
+	v, ok := s.state[k]
+
+	if !ok {
+		return ""
+	}
+
+	if start < 0 {
+		start = l + start
+		if start < 0 {
+			start = 0
+		}
+	}
+
+	if end < 0 {
+		end = l + end
+	}
+
+	if end > l {
+		end = l - 1
+	}
+
+	return v[start : end+1]
+}

--- a/storage/commands.go
+++ b/storage/commands.go
@@ -218,3 +218,10 @@ func (s *Storage) RenameNX(k, nk string) (bool, error) {
 
 	return true, nil
 }
+
+func (s *Storage) GetSet(k, v string) string {
+	ov := s.state[k]
+	s.state[k] = v
+
+	return ov
+}

--- a/storage/commands.go
+++ b/storage/commands.go
@@ -206,3 +206,15 @@ func (s *Storage) Rename(k, nk string) (bool, error) {
 
 	return true, nil
 }
+
+func (s *Storage) RenameNX(k, nk string) (bool, error) {
+	if _, ok := s.state[nk]; ok {
+		return false, nil
+	}
+
+	if ok, err := s.Rename(k, nk); !ok {
+		return ok, err
+	}
+
+	return true, nil
+}

--- a/storage/commands.go
+++ b/storage/commands.go
@@ -149,7 +149,7 @@ func (s *Storage) StrLen(k string) int {
 func (s *Storage) Del(ks ...string) int {
 	t := 0
 
-	for i, _ := range ks {
+	for i := range ks {
 		if _, ok := s.state[ks[i]]; ok {
 			t++
 			delete(s.state, ks[i])
@@ -170,26 +170,25 @@ func (s *Storage) Exists(k string) bool {
 }
 
 func (s *Storage) GetRange(k string, start, end int) string {
-	l := len(s.state[k])
+	length := len(s.state[k])
 	v, ok := s.state[k]
-
 	if !ok {
 		return ""
 	}
 
 	if start < 0 {
-		start = l + start
+		start = length + start
 		if start < 0 {
 			start = 0
 		}
 	}
 
 	if end < 0 {
-		end = l + end
+		end = length + end
 	}
 
-	if end > l {
-		end = l - 1
+	if end > length {
+		end = length - 1
 	}
 
 	return v[start : end+1]
@@ -220,8 +219,8 @@ func (s *Storage) RenameNX(k, nk string) (bool, error) {
 }
 
 func (s *Storage) GetSet(k, v string) string {
-	ov := s.state[k]
+	oldV := s.state[k]
 	s.state[k] = v
 
-	return ov
+	return oldV
 }

--- a/storage/commands_test.go
+++ b/storage/commands_test.go
@@ -150,3 +150,20 @@ func TestStrLen(t *testing.T) {
 		t.Error("must return 5")
 	}
 }
+
+func TestDel(t *testing.T) {
+	s := storage.New()
+
+	s.MSetNX("key1", "value1", "key2", "value2")
+	if v := s.Del("key1", "key3"); v != 1 {
+		t.Errorf("must return the total of deleted keys")
+	}
+
+	if v := s.Get("key1"); v != "" {
+		t.Errorf("key1 must have been deleted")
+	}
+
+	if v := s.Get("key2"); v != "value2" {
+		t.Errorf("key2 must not have been deleted")
+	}
+}

--- a/storage/commands_test.go
+++ b/storage/commands_test.go
@@ -167,3 +167,17 @@ func TestDel(t *testing.T) {
 		t.Errorf("key2 must not have been deleted")
 	}
 }
+
+func TestFlushAll(t *testing.T) {
+	s := storage.New()
+
+	s.MSetNX("key1", "value1", "key2", "value2")
+	s.FlushAll()
+
+	keys := [2]string{"key1", "key2"}
+	for i, _ := range keys {
+		if v := s.Get(keys[i]); v != "" {
+			t.Errorf("%s must have been deleted", keys[i])
+		}
+	}
+}

--- a/storage/commands_test.go
+++ b/storage/commands_test.go
@@ -181,3 +181,17 @@ func TestFlushAll(t *testing.T) {
 		}
 	}
 }
+
+func TestExists(t *testing.T) {
+	s := storage.New()
+
+	s.Set("key", "value")
+
+	if v := s.Exists("key"); !v {
+		t.Errorf("must return true when existing key")
+	}
+
+	if v := s.Exists("nkey"); v {
+		t.Errorf("must return false when non existent key")
+	}
+}

--- a/storage/commands_test.go
+++ b/storage/commands_test.go
@@ -195,3 +195,37 @@ func TestExists(t *testing.T) {
 		t.Errorf("must return false when non existent key")
 	}
 }
+
+func TestGetRange(t *testing.T) {
+	s := storage.New()
+
+	s.Set("key", "This is a string")
+
+	if v := s.GetRange("key", 0, 3); v != "This" {
+		t.Errorf("must return 'This' but '%s' was returned", v)
+	}
+
+	if v := s.GetRange("key", -3, -1); v != "ing" {
+		t.Errorf("must return 'ing' but '%s' was returned", v)
+	}
+
+	if v := s.GetRange("key", 0, -1); v != "This is a string" {
+		t.Errorf("must return 'This is a string' but '%s' was returned", v)
+	}
+
+	if v := s.GetRange("key", 10, 100); v != "string" {
+		t.Errorf("must return 'string' but '%s' was returned", v)
+	}
+
+	if v := s.GetRange("key", -100, 100); v != "This is a string" {
+		t.Errorf("must return 'This is a string' but '%s' was returned", v)
+	}
+
+	if v := s.GetRange("key", 0, 0); v != "T" {
+		t.Errorf("must return 'T' but '%s' was returned", v)
+	}
+
+	if v := s.GetRange("nkey", 0, 2); v != "" {
+		t.Errorf("must return an empty string but '%s' was returned", v)
+	}
+}

--- a/storage/commands_test.go
+++ b/storage/commands_test.go
@@ -251,3 +251,28 @@ func TestRename(t *testing.T) {
 		t.Errorf("must return an error when non existent key")
 	}
 }
+
+func TestRenameNX(t *testing.T) {
+	s := storage.New()
+
+	s.MSet("key1", "value1", "key2", "value2", "key3", "value3")
+	if ok, _ := s.RenameNX("key1", "newKey"); !ok {
+		t.Errorf("must return true and renamed key")
+	}
+
+	if ok, _ := s.RenameNX("key2", "key3"); ok {
+		t.Errorf("must return false when have conflicting keys")
+	}
+
+	if v := s.Get("newKey"); v != "value1" {
+		t.Errorf("newKey must contain the old key value")
+	}
+
+	if v := s.Get("key1"); v != "" {
+		t.Errorf("key1 must have been deleted")
+	}
+
+	if _, err := s.RenameNX("nkey", "key1"); err == nil {
+		t.Errorf("must return an error when non existent key")
+	}
+}

--- a/storage/commands_test.go
+++ b/storage/commands_test.go
@@ -276,3 +276,19 @@ func TestRenameNX(t *testing.T) {
 		t.Errorf("must return an error when non existent key")
 	}
 }
+
+func TestGetSet(t *testing.T) {
+	s := storage.New()
+
+	if v := s.GetSet("key", "value1"); v != "" {
+		t.Errorf("must return an empty string")
+	}
+
+	if v := s.Get("key"); v != "value1" {
+		t.Errorf("must return 'value1'")
+	}
+
+	if v := s.GetSet("key", "value2"); v != "value1" {
+		t.Errorf("must return old value")
+	}
+}

--- a/storage/commands_test.go
+++ b/storage/commands_test.go
@@ -229,3 +229,25 @@ func TestGetRange(t *testing.T) {
 		t.Errorf("must return an empty string but '%s' was returned", v)
 	}
 }
+
+func TestRename(t *testing.T) {
+	s := storage.New()
+
+	s.Set("key", "value")
+
+	if ok, _ := s.Rename("key", "newKey"); !ok {
+		t.Errorf("must return true and renamed key")
+	}
+
+	if v := s.Get("newKey"); v != "value" {
+		t.Errorf("newKey must contain the old key value")
+	}
+
+	if v := s.Get("key"); v != "" {
+		t.Errorf("key must have been deleted")
+	}
+
+	if _, err := s.Rename("nkey", "key1"); err == nil {
+		t.Errorf("must return an error when non existent key")
+	}
+}


### PR DESCRIPTION
Adds some commands to manipulate the map
- [x] [Del](http://redis.io/commands/del)
- [x] [FlushAll](http://redis.io/commands/flushall)
- [x] [Rename](http://redis.io/commands/rename)
- [x] [RenameNX](http://redis.io/commands/renamenx)

Also adds a string manipulation command

- [x] [GetRange](http://redis.io/commands/getrange)
- [X] [GetSet](http://redis.io/commands/getset)

These commands are based on the redis documentation.
Instead of return 1 or 0, like redis, true or false was returned when necessary.
In  particular case of Rename and RenameNX that returns an error if have unexistent key, a [basic error](https://golang.org/pkg/errors/#example_New) was created to represent this.
To GetSet, when new key is set, return empty string instead of nil like redis.